### PR TITLE
overlay: Bring back debug.mdpcomp.maxlayer

### DIFF
--- a/liboverlay/overlay.cpp
+++ b/liboverlay/overlay.cpp
@@ -38,7 +38,13 @@ namespace overlay {
 using namespace utils;
 
 Overlay::Overlay() {
-    PipeBook::NUM_PIPES = qdutils::MDPVersion::getInstance().getTotalPipes();
+    char property[PROPERTY_VALUE_MAX];
+    if (property_get("debug.mdpcomp.maxlayer", property, NULL) > 0) {
+        PipeBook::NUM_PIPES = atoi(property);
+    } else {
+        PipeBook::NUM_PIPES = qdutils::MDPVersion::getInstance().getTotalPipes();
+    }
+
     for(int i = 0; i < PipeBook::NUM_PIPES; i++) {
         mPipeBook[i].init();
     }


### PR DESCRIPTION
- We're having underrun issues with 4-layer composition. It generally
  works, but when the system CPU ramps down and the device is mostly
  idle, underrun is happening.
- Limiting to 3 layers solves the problem temporarily on these devices.
- Readd the option so that the issue can be debugged without afflicting
  our current users with massive amounts of flickering.

Change-Id: I7ab7d013f65eaf12a3d21a91229dcaad6a815069
